### PR TITLE
Ignore node_modules when mounting volumes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# ignore node_modules when building
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,19 +6,16 @@ LABEL Marcel Belmont "marcelbelmont@gmail.com"
 ENV appDir /var/www/app
 ENV NODE_SASS_PLATFORM alpine
 
-# Run updates and install deps
-RUN apk add --no-cache make gcc g++ python
-
 # Set the work directory
 RUN mkdir -p ${appDir}
 WORKDIR ${appDir}
 
+# Add application files
+ADD . ${appDir}
+
 # Install npm dependencies and install ava globally
 RUN npm install
 RUN npm install -g ava
-
-# Add application files
-ADD . ${appDir}
 
 # Define mountable directories.
 VOLUME ["/usr/local/var/lib/couchdb"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       DOCKER: "true"
     volumes:
       - .:/var/www/app
+      - /var/www/app/node_modules
     ports:
       - "8080:8080"
     links:
@@ -15,6 +16,7 @@ services:
     working_dir: /var/www/app
     volumes:
       - .:/var/www/app
+      - /var/www/app/node_modules
     environment:
       NODE_ENV: testing
     command:


### PR DESCRIPTION
Ensure that files are added to build before node_modules are installed.