### PR TITLE
Update docker-compose so tests run

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     working_dir: /var/www/app
     volumes:
       - .:/var/www/app
-      - /var/www/app/node_modules
+   #   - /var/www/app/node_modules
     environment:
       NODE_ENV: testing
     command:


### PR DESCRIPTION
Changed volumes setting in docker compose for test container to comment out - /var/www/app/node_modules
node_modules need to be available for the tests to run 